### PR TITLE
APM-1943 Remove e2e from internalqa

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -57,7 +57,6 @@ extends:
         post_deploy:
           - template: ./templates/run-tests.yml
             parameters:
-              e2e_tests: true
               smoke_tests: true
       - environment: internal-qa-sandbox
         proxy_path: sandbox


### PR DESCRIPTION
## Summary
* Routine Change

Removing e2e tests from internal qa as user identity token for testing only valid on internal-dev.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
