### PR TITLE
APM-1162 Don't add NHS User ID header again

### DIFF
--- a/proxies/live/apiproxy/targets/ih-target.xml
+++ b/proxies/live/apiproxy/targets/ih-target.xml
@@ -108,9 +108,6 @@
         <Name>Javascript.AddClientRPDetailsHeader</Name>
       </Step>
       <Step>
-        <Name>AssignMessage.AddUserIdHeader</Name>
-      </Step>
-      <Step>
         <Name>Quota</Name>
       </Step>
       <Step>


### PR DESCRIPTION
We want to send `<HEADER>` in `NHSD-User-Identity`, but due to this policy we actually send `<HEADER>,<HEADER>`. We shouldn't do that.